### PR TITLE
fix(TC-122) :: 이석 작성 버튼 중복 클릭 방지

### DIFF
--- a/src/components/layout/modal/confirm/index.tsx
+++ b/src/components/layout/modal/confirm/index.tsx
@@ -10,6 +10,7 @@ interface ConfirmModalProps {
     message: string | React.ReactNode
     cancelText?: string
     confirmText?: string
+    isLoading?: boolean
 }
 
 export default function ConfirmModal({
@@ -19,7 +20,8 @@ export default function ConfirmModal({
     title,
     message,
     cancelText = "취소",
-    confirmText = "확인"
+    confirmText = "확인",
+    isLoading = false
 }: ConfirmModalProps) {
     return (
         <Modal isOpen={isOpen} onClose={onClose} padding="2.5rem">
@@ -28,7 +30,7 @@ export default function ConfirmModal({
                 <S.Message>{message}</S.Message>
                 <S.ButtonGroup>
                     <Button variant="cancel" text={cancelText} onClick={onClose} />
-                    <Button variant="confirm" text={confirmText} onClick={onConfirm} />
+                    <Button variant="confirm" text={confirmText} onClick={onConfirm} isLoading={isLoading} />
                 </S.ButtonGroup>
             </S.Container>
         </Modal>

--- a/src/components/ui/button/index.tsx
+++ b/src/components/ui/button/index.tsx
@@ -21,12 +21,9 @@ export default function Button({ text, onClick, variant, width, isLoading = fals
       onClick={handleClick}
       $variant={variant}
       $width={width}
-      $disabled={isLoading}
-      disabled={isLoading}
-      style={{ cursor: isLoading ? 'not-allowed' : 'pointer' }}
     >
       <S.Name>
-        {isLoading ? '로딩 중...' : text}
+        {text}
       </S.Name>
     </S.Container>
   );

--- a/src/containers/manage-student/movement/map/index.tsx
+++ b/src/containers/manage-student/movement/map/index.tsx
@@ -30,6 +30,7 @@ export default function MovementMap({ onBack, formData }: MovementMapProps) {
     const [selectedFloor, setSelectedFloor] = useState(1);
     const [searchQuery, setSearchQuery] = useState('');
     const [highlightedPlace, setHighlightedPlace] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
     const [confirmModal, setConfirmModal] = useState<{
         isOpen: boolean;
         placeName: string;
@@ -73,6 +74,9 @@ export default function MovementMap({ onBack, formData }: MovementMapProps) {
     };
 
     const handleLocationClick = async (placeName: string) => {
+        // 이미 제출 중이면 무시
+        if (isSubmitting) return;
+
         // 이미 이석이 있는 장소인 경우 확인 모달 표시
         if (occupiedPlaces.has(placeName)) {
             const occupiedSeats = leaveSeatList.filter(seat => seat.place === placeName);
@@ -89,12 +93,14 @@ export default function MovementMap({ onBack, formData }: MovementMapProps) {
         
         if (placeName && placeName !== '' && placeName !== 'X') {
             try {
+                setIsSubmitting(true);
                 // 장소 검색 API로 실제 place_id 획득
                 const places = await searchPlaces(placeName, true);
                 const place = places.find(p => p.name === placeName);
                 
                 if (!place) {
                     toast.error('장소를 찾을 수 없습니다.');
+                    setIsSubmitting(false);
                     return;
                 }
                 
@@ -136,21 +142,26 @@ export default function MovementMap({ onBack, formData }: MovementMapProps) {
                 navigate('/manage/record');
             } catch (error) {
                 console.error(error);
+                setIsSubmitting(false);
             }
         }
     };
 
     const handleConfirmOccupiedPlace = async () => {
+        if (isSubmitting) return;
+
         const placeName = confirmModal.placeName;
         setConfirmModal({ isOpen: false, placeName: '', students: [] });
         
         try {
+            setIsSubmitting(true);
             // 장소 검색 API로 실제 place_id 획득
             const places = await searchPlaces(placeName, true);
             const place = places.find(p => p.name === placeName);
             
             if (!place) {
                 toast.error('장소를 찾을 수 없습니다.');
+                setIsSubmitting(false);
                 return;
             }
             
@@ -192,6 +203,7 @@ export default function MovementMap({ onBack, formData }: MovementMapProps) {
             navigate('/manage/record');
         } catch (error) {
             console.error(error);
+            setIsSubmitting(false);
         }
     };
 
@@ -324,6 +336,7 @@ export default function MovementMap({ onBack, formData }: MovementMapProps) {
                 onClose={() => setConfirmModal({ isOpen: false, placeName: '', students: [] })}
                 onConfirm={handleConfirmOccupiedPlace}
                 title="이미 이석이 등록된 장소입니다"
+                isLoading={isSubmitting}
                 message={
                     <div>
                         <div style={{ marginBottom: '12px' }}>

--- a/src/pages/admin/fixed-movement/create/index.tsx
+++ b/src/pages/admin/fixed-movement/create/index.tsx
@@ -24,6 +24,7 @@ export default function FixedMovementFormPage() {
   const queryClient = useQueryClient();
   const isProcessingTeam = useRef(false);
   const isProcessingStudent = useRef(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { data: detailData } = useQuery(fixedMovementQuery.detail(id));
   
@@ -205,6 +206,8 @@ export default function FixedMovementFormPage() {
   };
 
   const handleSubmit = async () => {
+    if (isSubmitting) return;
+
     const weekDay = WEEKDAY_LABEL_TO_API[dayOfWeek];
     const periodEnum = PERIOD_LABEL_TO_API[period];
 
@@ -219,6 +222,7 @@ export default function FixedMovementFormPage() {
     }
 
     try {
+      setIsSubmitting(true);
       if (isEditMode && id) {
         updateMutation.mutate({
           id,
@@ -229,6 +233,8 @@ export default function FixedMovementFormPage() {
             cause: reason,
             students: selectedStudents.map((s) => String(s.id ?? s.studentNumber)),
           },
+        }, {
+          onSettled: () => setIsSubmitting(false)
         });
         return;
       }
@@ -265,6 +271,7 @@ export default function FixedMovementFormPage() {
       navigate('/admin/fixed-movement');
     } catch (e) {
       toast.error('고정 이석 생성에 실패했습니다.');
+      setIsSubmitting(false);
     }
   };
 
@@ -452,7 +459,7 @@ export default function FixedMovementFormPage() {
 
       <S.ButtonRow>
         <Button text="취소" variant="cancel" width='27rem' onClick={handleCancel} />
-        <Button text="완료" variant="confirm" width='27rem' onClick={handleSubmit} />
+        <Button text="완료" variant="confirm" width='27rem' onClick={handleSubmit} isLoading={isSubmitting} />
       </S.ButtonRow>
     </S.Container>
   );


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #122

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)
이석 작성 및 관리자 고정 이석 설정 시, 버튼 중복 클릭으로 인해 데이터가 여러 번 생성되는 문제를 해결했습니다.
이석 작성 시 버튼을 여러 번 눌러 데이터가 중복으로 생성되는 문제를 막기 위해 중복 클릭 방지 로직을 추가했습니다.

>

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 이석 작성 및 관리자 고정 이석 설정 시, 버튼 중복 클릭으로 인해 데이터가 여러 번 생성되는 문제를 해결했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)