### PR TITLE
fix(#128) :: 이석 작성 시 학생 목록 중복 저장되는 문제 수정

### DIFF
--- a/src/containers/manage-student/movement/form/index.tsx
+++ b/src/containers/manage-student/movement/form/index.tsx
@@ -35,12 +35,14 @@ export default function MovementForm({ onNext, onCancel, initialData, savedFormD
     const [studentSearch, setStudentSearch] = useState<string>('');
     const [isTeamMode, setIsTeamMode] = useState(false);
     const [selectedStudents, setSelectedStudents] = useState<Array<{ id: string; display: string }>>(
-        savedFormData?.studentDetails ||
-        (initialData ? dedupeStudentsById(initialData.students.map(student => ({
-            id: String(student.id),
-            display: `${student.number} ${student.name}`,
-        }))) : undefined) ||
-        (prefilledStudent ? [prefilledStudent] : [])
+        dedupeStudentsById(
+            savedFormData?.studentDetails ||
+            (initialData ? initialData.students.map(student => ({
+                id: String(student.id),
+                display: `${student.number} ${student.name}`,
+            })) : undefined) ||
+            (prefilledStudent ? [prefilledStudent] : [])
+        )
     );
 
     // initialData가 바뀌면 폼 상태를 업데이트 (savedFormData가 없을 때만)


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

>이석 작성 시 학생 목록이 중복으로 저장되는 문제를 수정했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 지도 화면에서 "뒤로가기"로 학생 선택 화면에 돌아왔을 때, 학생 목록 초기값을 다시 불러오는 부분에 중복 제거 로직이 빠져있던 것을 수정
- 학생 목록이 채워지는 모든 경로(뒤로가기 복원, 수정 모드 진입, 사전 선택된 학생)에 학생 ID 기준 중복 제거(dedupe) 적용


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)