### PR TITLE
fix(#130) :: 이미 등록된 장소 재등록 시 중복 학생 필터링 안 됨

### DIFF
--- a/src/containers/manage-student/movement/map/index.tsx
+++ b/src/containers/manage-student/movement/map/index.tsx
@@ -155,14 +155,18 @@ export default function MovementMap({ onBack, formData }: MovementMapProps) {
         setConfirmModal({ isOpen: false, placeName: '', students: [] });
 
         // 이미 이 장소에 등록된 학생은 제외하고 등록 (같은 학생 중복 등록 방지)
+        // 표시 문자열의 공백 유무 등 포맷 차이가 있을 수 있어 학번(숫자)만 추출해 비교한다
+        const extractStudentNumber = (text: string) => text.match(/^\d+/)?.[0] ?? text;
+        const registeredNumbers = new Set(alreadyRegistered.map(extractStudentNumber));
+
         const studentDetails = formData.studentDetails;
         let submitData = formData;
 
         if (studentDetails) {
             const duplicateNames = studentDetails
-                .filter(s => alreadyRegistered.includes(s.display))
+                .filter(s => registeredNumbers.has(extractStudentNumber(s.display)))
                 .map(s => s.display);
-            const uniqueStudentDetails = studentDetails.filter(s => !alreadyRegistered.includes(s.display));
+            const uniqueStudentDetails = studentDetails.filter(s => !registeredNumbers.has(extractStudentNumber(s.display)));
 
             if (duplicateNames.length > 0) {
                 if (uniqueStudentDetails.length === 0) {


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

>이미 이석이 등록된 장소에 재등록할 때 중복 학생 필터링이 정상 동작하지 않던 문제를 수정했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- #4에서 "이미 등록된 장소 재등록 시 중복 학생 제외" 로직을 추가했지만, 서버 응답 표시 문자열("2114이시은", 공백 없음)과 폼의 표시 문자열("2114 이시은", 공백 있음) 포맷이 달라 문자열 비교가 항상 실패하던 것을 확인
- 문자열 전체 비교 대신 학번(숫자) 부분만 추출해서 비교하도록 수정 (`map/index.tsx`)

<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)