### PR TITLE
fix(#132) :: 이석 수정 시 중복 학생이 하나가 아니라 둘 다 삭제되는 문제 수정

### DIFF
--- a/src/containers/manage-student/movement/map/index.tsx
+++ b/src/containers/manage-student/movement/map/index.tsx
@@ -18,7 +18,7 @@ import * as S from './style';
 
 interface MovementMapProps {
     onBack: () => void;
-    formData: MovementFormData;
+    formData: MovementFormData;``
 }
 
 export default function MovementMap({ onBack, formData }: MovementMapProps) {
@@ -59,8 +59,11 @@ export default function MovementMap({ onBack, formData }: MovementMapProps) {
         enabled: debouncedSearchQuery.length > 0,
     });
     
-    // 이석이 있는 장소 목록
-    const occupiedPlaces = new Set(leaveSeatList.map(seat => seat.place));
+    // 이석이 있는 장소 목록 (수정 모드에서는 지금 수정 중인 기록 자신은 제외)
+    const otherLeaveSeatList = isEditMode && editId
+        ? leaveSeatList.filter(seat => String(seat.leaveseat_id) !== editId)
+        : leaveSeatList;
+    const occupiedPlaces = new Set(otherLeaveSeatList.map(seat => seat.place));
 
     const handleSelectPlace = (place: { name: string; floor: number }) => {
         setSelectedFloor(place.floor);
@@ -79,7 +82,7 @@ export default function MovementMap({ onBack, formData }: MovementMapProps) {
 
         // 이미 이석이 있는 장소인 경우 확인 모달 표시
         if (occupiedPlaces.has(placeName)) {
-            const occupiedSeats = leaveSeatList.filter(seat => seat.place === placeName);
+            const occupiedSeats = otherLeaveSeatList.filter(seat => seat.place === placeName);
             const studentNames = occupiedSeats.flatMap(seat => seat.students);
             const uniqueStudentNames = [...new Set(studentNames)]; // 중복 제거
             

--- a/src/containers/manage-student/movement/map/index.tsx
+++ b/src/containers/manage-student/movement/map/index.tsx
@@ -18,7 +18,7 @@ import * as S from './style';
 
 interface MovementMapProps {
     onBack: () => void;
-    formData: MovementFormData;``
+    formData: MovementFormData;
 }
 
 export default function MovementMap({ onBack, formData }: MovementMapProps) {


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 이석 수정 시 중복된 학생을 지우면 1개만 지워져야 하는데 2개(둘 다) 지워지는 문제를 수정했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- "이미 등록된 장소/학생"인지 판단할 때 쓰는 이석 목록에 지금 수정 중인 기록 자기 자신도 포함되어 있어서, 자신의 기존 학생을 "이미 등록된 학생"으로 잘못 인식해 중복 필터링 시 남아야 할 1개까지 같이 삭제되던 문제 확인
- 수정 모드일 때는 이석 목록에서 현재 수정 중인 기록을 제외하고 "이미 등록된 장소/학생"을 판단하도록 수정



<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)